### PR TITLE
Finding multiple entities from a list of IDs

### DIFF
--- a/src/main/java/io/restzilla/service/CrudService.java
+++ b/src/main/java/io/restzilla/service/CrudService.java
@@ -28,6 +28,13 @@ public interface CrudService<T extends Persistable<ID>, ID extends Serializable>
      * @return all entities
      */
     List<T> findAll();
+
+    /**
+     * Returns all entities matching the specified IDs
+     * @param ids IDs to find the entities for.
+     * @return All found entities.
+     */
+    List<T> findAll(Iterable<ID> ids);
     
     /**
      * Returns all entities, sorted.

--- a/src/main/java/io/restzilla/service/DefaultCrudService.java
+++ b/src/main/java/io/restzilla/service/DefaultCrudService.java
@@ -18,6 +18,8 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import com.google.common.collect.Lists;
+
 /**
  * Default implementation of the CRUD service, delegates all to the repository.
  *
@@ -92,6 +94,11 @@ public class DefaultCrudService<T extends Persistable<ID>, ID extends Serializab
     @Transactional(readOnly = true)
     public List<T> findAll() {
         return getByCacheOrExecute("findAll()", () -> (List<T>) repository.findAll());
+    }
+
+    @Override
+    public List<T> findAll(Iterable<ID> ids) {
+        return Lists.newArrayList(repository.findAll(ids));
     }
 
     /**


### PR DESCRIPTION
The repository present within `DefaultCrudService` offers the method `findAll(Iterable<ID> ids)`, but `DefaultCrudService` did not expose this method yet.
This pull request adds this method to `DefaultCrudService`.