### PR TITLE
Fixed NoSuchMethodError when running with the latest beanmapper-spring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .project
 /build/
 /target/
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>io.beanmapper</groupId>
             <artifactId>beanmapper-spring</artifactId>
-            <version>0.1.4</version>
+            <version>2.4.1</version>
             <scope>provided</scope>
         </dependency>
         

--- a/src/main/java/io/restzilla/service/AbstractCrudService.java
+++ b/src/main/java/io/restzilla/service/AbstractCrudService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
 
+import io.restzilla.util.LazyEntityRetrievalException;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.data.domain.Persistable;
 import org.springframework.transaction.annotation.Transactional;
@@ -74,7 +75,11 @@ public abstract class AbstractCrudService<T extends Persistable<ID>, ID extends 
      */
     @Override
     public <S extends T> S save(Lazy<S> entity) {
-        return save(entity.get());
+        try {
+            return save(entity.get());
+        } catch (Exception e) {
+            throw new LazyEntityRetrievalException(e);
+        }
     }
 
     /**

--- a/src/main/java/io/restzilla/util/LazyEntityRetrievalException.java
+++ b/src/main/java/io/restzilla/util/LazyEntityRetrievalException.java
@@ -1,0 +1,12 @@
+package io.restzilla.util;
+
+/**
+ * LazyEntityRetrievalException is a runtime exception which is thrown when the underlying BeanMapper failed to obtain a Lazy entity
+ * In such case, we are usually outside of the Hibernate session in which the Lazy wrapper was retrieved.
+ */
+public class LazyEntityRetrievalException extends RuntimeException {
+
+    public LazyEntityRetrievalException(Exception e) {
+        super(e);
+    }
+}

--- a/src/test/java/io/restzilla/RestTest.java
+++ b/src/test/java/io/restzilla/RestTest.java
@@ -27,6 +27,7 @@ import io.restzilla.model.dto.ValidationDto;
 
 import java.util.Arrays;
 
+import io.restzilla.util.LazyEntityRetrievalException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -529,7 +530,8 @@ public class RestTest extends AbstractControllerTest {
             
             Assert.fail("Expected an UnsupportedOperationException.");
         } catch (NestedServletException nse) {
-            Assert.assertEquals(UnsupportedOperationException.class, nse.getCause().getClass());
+            Assert.assertEquals(LazyEntityRetrievalException.class, nse.getCause().getClass());
+            Assert.assertEquals(UnsupportedOperationException.class, nse.getCause().getCause().getClass());
         }
 
         WithRollback result = entityBuilder.get(WithRollback.class, entity.getId());


### PR DESCRIPTION
Made restzilla compatible with the latest version of beanmapper-spring